### PR TITLE
Refine styling for air quality explorer

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,23 +26,32 @@ if (!app) {
   throw new Error('App container not found');
 }
 
-app.className = 'flex min-h-screen flex-col gap-6 bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 p-4 text-slate-100';
+app.className = 'relative mx-auto flex min-h-screen w-full max-w-[1600px] flex-col gap-10 px-6 py-10 text-slate-100';
+
+const glow = document.createElement('div');
+glow.className =
+  'pointer-events-none absolute inset-0 -z-10 rounded-[48px] border border-white/10 bg-gradient-to-br from-white/5 via-transparent to-primary/10 shadow-[0_50px_140px_-60px_rgba(30,64,175,0.7)]';
+app.appendChild(glow);
 
 const layout = document.createElement('div');
-layout.className = 'mx-auto flex w-full max-w-[1440px] flex-1 flex-col gap-4 lg:flex-row';
+layout.className = 'relative grid flex-1 grid-cols-1 gap-6 xl:grid-cols-[420px_1fr] xl:items-start';
 app.appendChild(layout);
 
 const controlPanel = document.createElement('aside');
 const mapPanel = document.createElement('section');
-mapPanel.className = 'relative flex-1 overflow-hidden rounded-2xl bg-slate-200/20 shadow-2xl ring-1 ring-slate-100/10 dark:bg-slate-900/40';
-controlPanel.className = 'w-full lg:w-96';
+mapPanel.className =
+  'relative flex min-h-[600px] flex-1 overflow-hidden rounded-3xl border border-white/10 bg-slate-900/50 shadow-[0_40px_120px_-60px_rgba(15,23,42,1)] backdrop-blur-2xl';
+controlPanel.className = 'w-full xl:w-[420px]';
 layout.appendChild(controlPanel);
 layout.appendChild(mapPanel);
 
 const loading = document.createElement('div');
-loading.className = 'flex h-full items-center justify-center text-sm text-slate-400';
+loading.className = 'flex h-full items-center justify-center text-sm font-medium text-slate-400';
 loading.textContent = 'Loading datasets…';
 mapPanel.appendChild(loading);
+const overlay = document.createElement('div');
+overlay.className = 'map-panel-overlay';
+mapPanel.appendChild(overlay);
 
 const { weights: initialWeights, active: initialActive } = UIController.initialWeights();
 

--- a/src/map.ts
+++ b/src/map.ts
@@ -89,7 +89,7 @@ export class CountyMap {
       .append('svg')
       .attr('role', 'img')
       .attr('aria-label', 'Map of U.S. counties')
-      .attr('class', 'w-full h-full');
+      .attr('class', 'h-full w-full');
 
     const defs = this.svg.append('defs');
     const pattern = defs
@@ -115,12 +115,12 @@ export class CountyMap {
     this.tooltip = d3
       .select(container)
       .append('div')
-      .attr('class', 'pointer-events-none absolute hidden rounded-lg bg-slate-900/90 px-4 py-3 text-sm shadow-xl backdrop-blur text-slate-100');
+      .attr('class', 'map-tooltip');
 
     this.legend = d3
       .select(container)
       .append('div')
-      .attr('class', 'absolute right-4 top-4 z-10 flex w-56 flex-col gap-2 rounded-xl bg-white/90 p-3 text-xs text-slate-700 shadow-lg dark:bg-slate-900/90 dark:text-slate-200');
+      .attr('class', 'map-legend');
 
     this.setupZoom();
     this.prepareLayers(geography);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -6,25 +8,143 @@
   color-scheme: light dark;
 }
 
-a {
-  @apply text-primary underline;
-}
+@layer base {
+  html {
+    @apply scroll-smooth;
+  }
 
-body {
-  @apply bg-slate-100 text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100;
+  body {
+    font-family: 'Plus Jakarta Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    @apply bg-slate-950 text-slate-100 antialiased;
+    background-image: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.12), transparent 45%),
+      radial-gradient(circle at 80% 10%, rgba(129, 140, 248, 0.18), transparent 50%),
+      radial-gradient(circle at 50% 80%, rgba(45, 212, 191, 0.12), transparent 40%);
+    background-attachment: fixed;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5 {
+    @apply font-semibold text-slate-900 dark:text-slate-100;
+  }
+
+  a {
+    @apply font-semibold text-primary transition hover:text-primary/80;
+  }
 }
 
 .card {
-  @apply rounded-xl bg-white/90 p-4 shadow-lg backdrop-blur dark:bg-slate-900/90;
+  @apply relative overflow-hidden rounded-3xl border border-white/15 bg-white/70 p-6 shadow-[0_30px_90px_-45px_rgba(15,23,42,0.9)] backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/70;
 }
 
-button:focus-visible,
-input:focus-visible,
-select:focus-visible {
-  @apply outline-none ring-2 ring-primary/60 ring-offset-2 ring-offset-slate-100 dark:ring-offset-slate-900;
+.card::before {
+  content: '';
+  @apply pointer-events-none absolute -right-20 top-10 h-56 w-56 rounded-full bg-primary/20 blur-3xl;
 }
 
-[data-hatched="true"] {
+.card::after {
+  content: '';
+  @apply pointer-events-none absolute -bottom-16 left-12 h-44 w-44 rounded-full bg-emerald-400/10 blur-3xl;
+}
+
+.control-label {
+  @apply text-[13px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-300;
+}
+
+.form-control {
+  @apply w-full rounded-2xl border border-white/30 bg-white/80 px-4 py-2.5 text-sm font-medium text-slate-800 shadow-inner transition focus:border-primary/40 focus:outline-none focus:ring-2 focus:ring-primary/30 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100 dark:shadow-[inset_0_1px_0_0_rgba(148,163,184,0.12)];
+}
+
+.input-description {
+  @apply text-xs leading-relaxed text-slate-500 dark:text-slate-300;
+}
+
+.section-heading {
+  @apply text-xs font-semibold uppercase tracking-[0.32em] text-primary/80;
+}
+
+.panel-surface {
+  @apply rounded-2xl border border-white/10 bg-white/60 p-4 shadow-inner transition dark:border-white/10 dark:bg-slate-900/40;
+}
+
+.panel-surface:hover {
+  @apply border-primary/40 shadow-[0_18px_48px_-30px_rgba(30,64,175,0.6)];
+}
+
+.btn-link {
+  @apply text-xs font-semibold text-primary transition hover:text-primary/80;
+}
+
+.btn-primary {
+  @apply inline-flex items-center justify-center rounded-full bg-gradient-to-r from-primary to-indigo-500 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white shadow-lg shadow-primary/25 transition hover:from-primary/90 hover:to-indigo-500/90;
+}
+
+.btn-pill {
+  @apply rounded-full border border-transparent bg-white/70 px-3 py-1 text-xs font-medium text-slate-700 shadow-sm transition hover:border-primary/40 hover:bg-primary/10 dark:bg-slate-900/60 dark:text-slate-100;
+}
+
+.search-result {
+  @apply flex flex-col gap-0.5 rounded-2xl border border-transparent bg-white/70 px-3 py-2 text-left text-sm text-slate-700 transition hover:border-primary/40 hover:bg-primary/10 dark:bg-slate-900/60 dark:text-slate-100;
+}
+
+.search-result span {
+  @apply font-mono text-[11px] text-slate-400;
+}
+
+.weight-percent {
+  @apply w-12 text-right text-xs font-semibold tabular-nums text-slate-500 transition group-hover:text-primary/80;
+}
+
+input[type='range'] {
+  accent-color: theme('colors.primary');
+}
+
+input[type='range']::-webkit-slider-runnable-track {
+  height: 0.35rem;
+  border-radius: 9999px;
+  background: linear-gradient(90deg, rgba(29, 78, 216, 0.65), rgba(129, 140, 248, 0.6));
+}
+
+input[type='range']::-webkit-slider-thumb {
+  margin-top: -6px;
+  width: 18px;
+  height: 18px;
+  border-radius: 9999px;
+  background: white;
+  border: 2px solid rgba(29, 78, 216, 0.7);
+  box-shadow: 0 10px 30px -12px rgba(30, 64, 175, 0.7);
+}
+
+input[type='range']::-moz-range-track {
+  height: 0.35rem;
+  border-radius: 9999px;
+  background: linear-gradient(90deg, rgba(29, 78, 216, 0.65), rgba(129, 140, 248, 0.6));
+}
+
+input[type='range']::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 9999px;
+  background: white;
+  border: 2px solid rgba(29, 78, 216, 0.7);
+  box-shadow: 0 10px 30px -12px rgba(30, 64, 175, 0.7);
+}
+
+.map-panel-overlay {
+  @apply pointer-events-none absolute inset-0 rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-transparent to-primary/15;
+}
+
+.map-legend {
+  @apply absolute right-4 top-4 z-10 flex w-60 flex-col gap-2 rounded-2xl border border-white/20 bg-white/80 p-4 text-xs text-slate-700 shadow-xl backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-200;
+}
+
+.map-tooltip {
+  @apply pointer-events-none absolute hidden max-w-xs rounded-2xl border border-primary/30 bg-slate-950/90 px-5 py-4 text-sm text-slate-100 shadow-2xl backdrop-blur;
+}
+
+[data-hatched='true'] {
   background-image: repeating-linear-gradient(
     45deg,
     rgba(15, 23, 42, 0.2) 0,

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -61,22 +61,24 @@ function createWeightControls(
   active: Record<PlaceKey, boolean>,
   onChange: (nextWeights: WeightConfig, nextActive: Record<PlaceKey, boolean>) => void
 ) {
-  const wrapper = d3.select(container).append('div').attr('class', 'flex flex-col gap-3');
+  const wrapper = d3.select(container).append('div').attr('class', 'flex flex-col gap-4');
   PLACE_KEYS.forEach((key) => {
-    const row = wrapper.append('div').attr('class', 'flex flex-col gap-1');
-    const labelRow = row.append('label').attr('class', 'flex items-center justify-between gap-3 text-sm font-medium');
+    const row = wrapper.append('div').attr('class', 'group panel-surface flex flex-col gap-3');
+    const labelRow = row
+      .append('label')
+      .attr('class', 'flex items-center justify-between gap-3 text-sm font-semibold text-slate-700 dark:text-slate-200');
     const label = key
       .replace('_pct', '')
       .replace('copd', 'COPD')
       .replace('hbi', 'HBI');
     labelRow
       .append('span')
-      .attr('class', 'capitalize')
+      .attr('class', 'text-base font-semibold capitalize text-slate-900 dark:text-white')
       .text(label.replace(/_/g, ' '));
     const toggle = labelRow
       .append('input')
       .attr('type', 'checkbox')
-      .attr('class', 'h-4 w-4 accent-primary')
+      .attr('class', 'h-4 w-4 rounded border border-white/40 bg-white/80 text-primary shadow-sm transition focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-white/10 dark:bg-slate-900/80')
       .property('checked', active[key])
       .on('change', (event) => {
         active[key] = (event.currentTarget as HTMLInputElement).checked;
@@ -84,14 +86,14 @@ function createWeightControls(
         onChange(normalized, { ...active });
       });
 
-    const controlRow = row.append('div').attr('class', 'flex items-center gap-3');
+    const controlRow = row.append('div').attr('class', 'flex items-center gap-4');
     const slider = controlRow
       .append('input')
       .attr('type', 'range')
       .attr('min', 0)
       .attr('max', 100)
       .attr('step', 1)
-      .attr('class', 'w-full accent-primary')
+      .attr('class', 'w-full')
       .property('value', Math.round(weights[key] * 100))
       .property('disabled', !active[key])
       .on('input', (event) => {
@@ -102,7 +104,7 @@ function createWeightControls(
       });
     controlRow
       .append('span')
-      .attr('class', 'w-10 text-right text-xs font-semibold tabular-nums text-slate-500')
+      .attr('class', 'weight-percent')
       .text(`${Math.round(weights[key] * 100)}%`);
 
     toggle.on('change.weight', () => {
@@ -161,22 +163,23 @@ export class UIController {
     this.weights = weights;
     this.active = active;
     this.options = options;
-    this.container.classList.add('card', 'flex', 'max-w-sm', 'flex-col', 'gap-6');
+    this.container.classList.add('card', 'flex', 'max-w-sm', 'flex-col', 'gap-7', 'text-slate-900', 'dark:text-slate-100');
     this.container.innerHTML = '';
 
     const title = document.createElement('div');
-    title.className = 'flex flex-col gap-1';
+    title.className = 'flex flex-col gap-2';
     title.innerHTML = `
-      <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">County Health vs Air Quality</h1>
-      <p class="text-sm text-slate-600 dark:text-slate-300">Explore CDC PLACES chronic disease burdens alongside PM₂.₅ exposure.</p>
+      <span class="section-heading">Environmental health explorer</span>
+      <h1 class="text-3xl font-semibold leading-tight text-transparent bg-gradient-to-r from-slate-900 via-primary/80 to-emerald-400 bg-clip-text dark:from-white dark:via-primary/80 dark:to-emerald-300">County Health vs Air Quality</h1>
+      <p class="input-description">Explore CDC PLACES chronic disease burdens alongside PM₂.₅ exposure to spot elevated health burdens across the United States.</p>
     `;
     this.container.appendChild(title);
 
     const metricGroup = document.createElement('div');
-    metricGroup.className = 'flex flex-col gap-2';
+    metricGroup.className = 'panel-surface flex flex-col gap-2';
     metricGroup.innerHTML = `
-      <label class="text-sm font-semibold">Map metric</label>
-      <select class="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900">
+      <label class="control-label">Map metric</label>
+      <select class="form-control">
         <option value="hbi">Health Burden Index</option>
         <option value="exposure">Exposure Index</option>
         <option value="residual">Residual (HBI - Expected)</option>
@@ -191,10 +194,10 @@ export class UIController {
     this.container.appendChild(metricGroup);
 
     const breakGroup = document.createElement('div');
-    breakGroup.className = 'flex flex-col gap-2';
+    breakGroup.className = 'panel-surface flex flex-col gap-2';
     breakGroup.innerHTML = `
-      <label class="text-sm font-semibold">Class breaks</label>
-      <select class="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900">
+      <label class="control-label">Class breaks</label>
+      <select class="form-control">
         <option value="quantile">Quantile (quintiles)</option>
         <option value="equal">Equal interval</option>
         <option value="jenks">Jenks (k-means)</option>
@@ -207,23 +210,26 @@ export class UIController {
     this.container.appendChild(breakGroup);
 
     const pmLabelGroup = document.createElement('div');
-    pmLabelGroup.className = 'flex flex-col gap-2';
+    pmLabelGroup.className = 'panel-surface flex flex-col gap-2';
     pmLabelGroup.innerHTML = `
-      <label class="text-sm font-semibold">PM₂.₅ averaging window</label>
-      <input type="text" class="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900" placeholder="2016–2024" value="2016–2024" />
+      <label class="control-label">PM₂.₅ averaging window</label>
+      <input type="text" class="form-control" placeholder="2016–2024" value="2016–2024" />
     `;
     this.pmLabelInput = pmLabelGroup.querySelector('input') as HTMLInputElement;
     this.pmLabelInput.addEventListener('input', () => this.options.onPmLabelChange(this.pmLabelInput.value || '2016–2024'));
     this.container.appendChild(pmLabelGroup);
 
     const builder = document.createElement('div');
-    builder.className = 'flex flex-col gap-3';
+    builder.className = 'flex flex-col gap-4';
     builder.innerHTML = `
-      <div class="flex items-center justify-between">
-        <h2 class="text-sm font-semibold">Health Burden Builder</h2>
-        <button type="button" class="text-xs font-medium text-primary hover:underline">Reset weights</button>
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex flex-col gap-1">
+          <span class="section-heading">Custom index</span>
+          <h2 class="text-lg font-semibold text-slate-900 dark:text-white">Health Burden Builder</h2>
+        </div>
+        <button type="button" class="btn-pill">Reset</button>
       </div>
-      <p class="text-xs text-slate-500 dark:text-slate-400">Select CDC PLACES measures and adjust their influence on the index. Weights re-normalize automatically.</p>
+      <p class="input-description">Select CDC PLACES measures and adjust their influence on the index. Weights re-normalize automatically.</p>
     `;
     const resetButton = builder.querySelector('button') as HTMLButtonElement;
     resetButton.addEventListener('click', () => {
@@ -239,19 +245,19 @@ export class UIController {
     this.container.appendChild(builder);
 
     this.weightPanel = document.createElement('div');
-    this.weightPanel.className = 'flex flex-col gap-3';
+    this.weightPanel.className = 'flex flex-col gap-4';
     this.container.appendChild(this.weightPanel);
     this.renderWeightPanel();
 
     const searchGroup = document.createElement('div');
-    searchGroup.className = 'flex flex-col gap-2';
+    searchGroup.className = 'panel-surface flex flex-col gap-3';
     searchGroup.innerHTML = `
-      <label class="text-sm font-semibold">Search counties</label>
-      <input type="search" class="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900" placeholder="Type a county or FIPS" />
-      <div class="flex flex-col gap-1 text-xs text-slate-500"></div>
+      <label class="control-label">Search counties</label>
+      <input type="search" class="form-control" placeholder="Type a county or FIPS" />
+      <div class="flex flex-col gap-2" data-role="search-results"></div>
     `;
     this.searchInput = searchGroup.querySelector('input') as HTMLInputElement;
-    this.searchResults = searchGroup.querySelector('div') as HTMLElement;
+    this.searchResults = searchGroup.querySelector('[data-role="search-results"]') as HTMLElement;
     this.searchInput.addEventListener('input', () => {
       const query = this.searchInput.value;
       if (!query) {
@@ -260,7 +266,10 @@ export class UIController {
       }
       const matches = searchMatches(this.data, query);
       this.searchResults.innerHTML = matches
-        .map((county) => `<button type="button" data-fips="${county.fips}" class="rounded px-2 py-1 text-left hover:bg-slate-200/70 dark:hover:bg-slate-800/70">${county.county}, ${county.state} <span class="font-mono text-[11px] text-slate-400">${county.fips}</span></button>`)
+        .map(
+          (county) =>
+            `<button type="button" data-fips="${county.fips}" class="search-result">${county.county}, ${county.state} <span>${county.fips}</span></button>`
+        )
         .join('');
     });
     this.searchResults.addEventListener('click', (event) => {
@@ -273,26 +282,29 @@ export class UIController {
     this.container.appendChild(searchGroup);
 
     this.outlierSection = document.createElement('div');
-    this.outlierSection.className = 'flex flex-col gap-3';
+    this.outlierSection.className = 'panel-surface flex flex-col gap-4';
     this.outlierSection.innerHTML = `
-      <div class="flex items-center justify-between">
-        <h2 class="text-sm font-semibold">High-burden outliers</h2>
-        <button type="button" class="rounded bg-primary px-3 py-1 text-xs font-semibold text-white shadow hover:bg-blue-600">Export CSV</button>
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex flex-col gap-1">
+          <span class="section-heading">Signal counties</span>
+          <h2 class="text-lg font-semibold text-slate-900 dark:text-white">High-burden outliers</h2>
+        </div>
+        <button type="button" class="btn-primary">Export CSV</button>
       </div>
-      <p class="text-xs text-slate-500 dark:text-slate-400">Counties whose observed burden exceeds the regression expectation given PM₂.₅.</p>
-      <div class="flex max-h-64 flex-col gap-1 overflow-y-auto"></div>
+      <p class="input-description">Counties whose observed burden exceeds the regression expectation given PM₂.₅.</p>
+      <div class="flex max-h-64 flex-col gap-2 overflow-y-auto pr-1" data-role="outlier-list"></div>
     `;
     this.outlierButton = this.outlierSection.querySelector('button') as HTMLButtonElement;
-    this.outlierList = this.outlierSection.querySelector('div.flex.max-h-64') as HTMLElement;
+    this.outlierList = this.outlierSection.querySelector('[data-role="outlier-list"]') as HTMLElement;
     this.outlierButton.addEventListener('click', () => this.exportOutliers());
     this.container.appendChild(this.outlierSection);
     this.toggleOutliers(false);
 
     const notes = document.createElement('div');
-    notes.className = 'rounded-lg bg-slate-100/60 p-3 text-xs leading-relaxed text-slate-600 dark:bg-slate-800/60 dark:text-slate-300';
+    notes.className = 'rounded-2xl border border-white/10 bg-white/50 p-4 text-xs leading-relaxed text-slate-600 shadow-inner dark:border-white/10 dark:bg-slate-900/50 dark:text-slate-200';
     notes.innerHTML = `
-      <p class="font-semibold">Data notes</p>
-      <ul class="mt-1 list-disc space-y-1 pl-4">
+      <p class="text-sm font-semibold text-slate-900 dark:text-white">Data notes</p>
+      <ul class="mt-2 list-disc space-y-1 pl-4">
         <li>CDC PLACES 2024 release (crude prevalence) for chronic conditions.</li>
         <li>EPA Air Quality System PM₂.₅ monitor annual means averaged across available monitors.</li>
         <li>Residuals derive from an ordinary least squares fit of HBI on PM₂.₅ exposure.</li>
@@ -341,16 +353,19 @@ export class UIController {
   updateOutliers(outliers: Outlier[]) {
     this.currentOutliers = outliers;
     if (!outliers.length) {
-      this.outlierList.innerHTML = '<p class="text-xs text-slate-500">No counties exceed the expected burden for the selected configuration.</p>';
+      this.outlierList.innerHTML = '<p class="input-description">No counties exceed the expected burden for the selected configuration.</p>';
       return;
     }
     this.outlierList.innerHTML = outliers
       .map(
         (item) => `
-        <button type="button" data-fips="${item.fips}" class="flex flex-col gap-1 rounded border border-slate-200 px-3 py-2 text-left text-xs hover:border-primary hover:bg-slate-100/70 dark:border-slate-700 dark:hover:border-primary/70 dark:hover:bg-slate-800/70">
-          <div class="flex items-center justify-between"><span class="font-semibold">${item.county}, ${item.state}</span><span class="font-mono text-[11px] text-slate-400">${item.fips}</span></div>
-          <div class="flex flex-wrap gap-x-3">
-            <span>Residual: <strong>${formatNumber(item.residual)}</strong></span>
+        <button type="button" data-fips="${item.fips}" class="group flex flex-col gap-2 rounded-2xl border border-white/20 bg-white/70 px-4 py-3 text-left text-xs text-slate-700 shadow-sm transition hover:border-primary/50 hover:bg-primary/10 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100">
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-sm font-semibold">${item.county}, ${item.state}</span>
+            <span class="font-mono text-[11px] text-slate-400">${item.fips}</span>
+          </div>
+          <div class="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-slate-500 transition group-hover:text-slate-600 dark:text-slate-300 dark:group-hover:text-slate-200">
+            <span>Residual: <strong class="text-slate-900 dark:text-white">${formatNumber(item.residual)}</strong></span>
             <span>Exposure: ${formatNumber(item.exposure)}</span>
             <span>HBI: ${formatNumber(item.hbi)}</span>
           </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,9 @@ export default {
     extend: {
       colors: {
         primary: '#1d4ed8'
+      },
+      fontFamily: {
+        sans: ['"Plus Jakarta Sans"', 'system-ui', 'sans-serif']
       }
     }
   },


### PR DESCRIPTION
## Summary
- Introduce a new Plus Jakarta Sans theme, glassmorphism cards, and gradient background accents for the explorer layout.
- Refresh control widgets, search, and outlier panels with cohesive surfaces, pill buttons, and consistent form styling.
- Polish the map container, legend, and tooltip to match the updated visual language.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d580c1146c8327a9086cea0e16ee4c