### PR TITLE
Fix temporal dead zone initialization bug

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -180,15 +180,15 @@ const ui = new UIController(controlPanel, { ...initialWeights }, { ...initialAct
     renderCountyDetails(state.selectedCounty);
   }
 });
-ui.setBreakMode(state.breakMode);
-ui.setBuilderVisibility(state.metric === 'hbi');
-ui.setOutlierVisibility(false);
-setMetric(state.metric);
-
 let derived: DerivedData | null = null;
 let baseCounties: CountyDatum[] = [];
 let mapInstance: CountyMap | null = null;
 let regressionBadge: HTMLDivElement | null = null;
+
+ui.setBreakMode(state.breakMode);
+ui.setBuilderVisibility(state.metric === 'hbi');
+ui.setOutlierVisibility(false);
+setMetric(state.metric);
 
 function withPercent(value: number | null): string {
   const formatted = formatNumber(value);


### PR DESCRIPTION
## Summary
- declare derived data references before invoking the initial metric setup
- ensure metric initialization runs after stateful references exist to prevent TDZ errors

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d586964610832788d9e5027acfc716