### PR TITLE
Update copy to refer to pollution instead of PM2.5 exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # County Health vs Air Quality
 
-Interactive static site that maps chronic disease burdens from CDC PLACES against fine particulate (PM2.5) exposure by U.S. county, highlights outliers, and ships ready for GitHub Pages hosting.
+Interactive static site that maps chronic disease burdens from CDC PLACES against fine particulate (PM2.5) pollution by U.S. county, highlights outliers, and ships ready for GitHub Pages hosting.
 
 ## Quick start
 
@@ -47,7 +47,7 @@ All required data live in the `data/` folder and are versioned in the repository
 ## Method
 
 1. **Data prep**
-   - Coerce all FIPS to five-character strings and left-join CDC PLACES to PM2.5 exposure on FIPS.
+   - Coerce all FIPS to five-character strings and left-join CDC PLACES to pollution on FIPS.
    - Drop counties missing PM2.5 or all selected PLACES measures. Counties with partial PLACES coverage are hatched on the map.
 2. **Health Burden Index (HBI)**
    - User-selectable subset of PLACES variables.

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,7 +63,7 @@ mapColumn.appendChild(metricTabs);
 const metricButtons = new Map<MetricKey, HTMLButtonElement>();
 const metricDetails: Record<MetricKey, string> = {
   hbi: 'Blended health burden',
-  exposure: 'PM₂.₅ exposure',
+  exposure: 'Pollution',
   residual: 'Health minus pollution'
 };
 (

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -170,7 +170,7 @@ export class UIController {
     title.innerHTML = `
       <span class="section-heading">Environmental health explorer</span>
       <h1 class="text-3xl font-semibold leading-tight text-transparent bg-gradient-to-r from-slate-900 via-primary/80 to-emerald-400 bg-clip-text dark:from-white dark:via-primary/80 dark:to-emerald-300">County Health vs Air Quality</h1>
-      <p class="input-description">Explore CDC PLACES chronic disease burdens alongside PM₂.₅ exposure to spot elevated health burdens across the United States.</p>
+      <p class="input-description">Explore CDC PLACES chronic disease burdens alongside pollution to spot elevated health burdens across the United States.</p>
     `;
     this.container.appendChild(title);
 
@@ -299,7 +299,7 @@ export class UIController {
       <ul class="mt-2 list-disc space-y-1 pl-4">
         <li>CDC PLACES 2024 release (crude prevalence) for chronic conditions.</li>
         <li>EPA Air Quality System PM₂.₅ monitor annual means averaged across available monitors.</li>
-        <li>Residuals derive from an ordinary least squares fit of HBI on PM₂.₅ exposure.</li>
+        <li>Residuals derive from an ordinary least squares fit of HBI on pollution.</li>
         <li>Methodology and limitations described in the README.</li>
       </ul>
     `;


### PR DESCRIPTION
## Summary
- replace "PM2.5 exposure" references in the README with "pollution"
- update UI strings to label the exposure metric as pollution in the app

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5877d66d08327bdc620249abe468c