### PR TITLE
Refine UI with blackout dark theme and remove county search

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="h-full bg-slate-950 text-slate-100">
+<html lang="en" class="h-full bg-[#020403] text-white">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,19 +25,19 @@ if (!app) {
   throw new Error('App container not found');
 }
 
-app.className = 'relative mx-auto flex min-h-screen w-full max-w-none flex-col gap-10 px-5 py-10 text-slate-100 xl:px-12';
+app.className = 'relative mx-auto flex min-h-screen w-full max-w-none flex-col gap-10 px-5 py-10 text-white xl:px-12';
 
 const glow = document.createElement('div');
 glow.className =
-  'pointer-events-none absolute inset-0 -z-10 rounded-[48px] border border-white/10 bg-gradient-to-br from-white/5 via-transparent to-primary/10 shadow-[0_50px_140px_-60px_rgba(30,64,175,0.7)]';
+  'pointer-events-none absolute inset-0 -z-10 rounded-[48px] border border-white/10 bg-gradient-to-br from-white/5 via-transparent to-primary/20 shadow-[0_60px_160px_-70px_rgba(53,94,59,0.8)]';
 app.appendChild(glow);
 
 const header = document.createElement('header');
-header.className = 'flex flex-col gap-4 text-slate-200';
+header.className = 'flex flex-col gap-4 text-white/80';
 header.innerHTML = `
   <span class="section-heading">Air &amp; health</span>
   <h1 class="text-4xl font-semibold leading-tight text-white">Where dirty air and chronic illness overlap</h1>
-  <p class="max-w-3xl text-base leading-relaxed text-slate-200">
+  <p class="max-w-3xl text-base leading-relaxed text-white/80">
     Use this explorer to see how long-term fine particle pollution relates to chronic disease burdens. Pick a map view below,
     then click a county to read its numbers in the table under the map.
   </p>
@@ -87,14 +87,14 @@ const metricDetails: Record<MetricKey, string> = {
 
 const mapPanel = document.createElement('div');
 mapPanel.className =
-  'relative flex min-h-[640px] flex-1 overflow-hidden rounded-[48px] border border-white/10 bg-slate-950/60 shadow-[0_80px_200px_-80px_rgba(15,23,42,1)] backdrop-blur-2xl xl:min-h-[760px]';
+  'relative flex min-h-[640px] flex-1 overflow-hidden rounded-[48px] border border-white/10 bg-black/70 shadow-[0_80px_200px_-90px_rgba(15,35,24,0.9)] backdrop-blur-2xl xl:min-h-[760px]';
 mapColumn.appendChild(mapPanel);
 
 const controlPanel = document.createElement('aside');
 controlPanel.className = 'relative z-10 w-full';
 
 const loading = document.createElement('div');
-loading.className = 'flex h-full w-full items-center justify-center text-sm font-medium text-slate-300';
+loading.className = 'flex h-full w-full items-center justify-center text-sm font-medium text-white/70';
 loading.textContent = 'Loading county and pollution data…';
 mapPanel.appendChild(loading);
 
@@ -107,7 +107,7 @@ detailsCard.className = 'card flex flex-col gap-4';
 detailsCard.innerHTML = `
   <div class="flex flex-col gap-1">
     <span class="section-heading">County snapshot</span>
-    <h2 class="text-lg font-semibold text-slate-900 dark:text-white">Click a county to read the data</h2>
+    <h2 class="text-lg font-semibold text-white">Click a county to read the data</h2>
   </div>
   <div class="county-details" data-role="county-details"></div>
 `;
@@ -118,13 +118,13 @@ mapColumn.appendChild(controlPanel);
 const detailsBody = detailsCard.querySelector('[data-role="county-details"]') as HTMLDivElement;
 
 const helperNote = document.createElement('div');
-helperNote.className = 'panel-surface text-sm leading-relaxed text-slate-600 dark:text-slate-200';
+helperNote.className = 'panel-surface text-sm leading-relaxed text-white/80';
 helperNote.innerHTML = `
-  <p class="text-sm font-semibold text-slate-900 dark:text-white">How to read this view</p>
+  <p class="text-sm font-semibold text-white">How to read this view</p>
   <ul class="mt-2 list-disc space-y-1 pl-5">
     <li>Tabs above the map switch between Health, air pollution, and the gap between them.</li>
     <li>Click any county to update the table and keep the numbers visible while you explore.</li>
-    <li>Use the controls on the right to change the color groupings, search for a place, or tweak the blended index weights.</li>
+    <li>Use the controls on the right to change the color groupings or tweak the blended index weights.</li>
   </ul>
 `;
 mapColumn.appendChild(helperNote);
@@ -150,19 +150,6 @@ const ui = new UIController(controlPanel, { ...initialWeights }, { ...initialAct
     state.weights = weights;
     state.activeMeasures = active;
     recalculate();
-  },
-  onSearch: (fips) => {
-    if (!mapInstance) return;
-    mapInstance.focusOnCounty(fips);
-    mapInstance.flashCounty(fips);
-    if (derived) {
-      const target = derived.counties.find((county) => county.fips === fips);
-      if (target) {
-        state.selectedCounty = target;
-        renderCountyDetails(target);
-        mapInstance.setSelectedCounty(target.fips);
-      }
-    }
   },
   onOutlierSelect: (fips) => {
     if (!mapInstance) return;
@@ -201,7 +188,7 @@ function renderCountyDetails(county: CountyDatum | null) {
   if (!detailsBody) return;
   if (!county) {
     detailsBody.innerHTML = `
-      <p class="text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+      <p class="text-sm leading-relaxed text-white/70">
         Click any county on the map to see its chronic disease burdens, pollution levels, and percentile ranks.
       </p>
     `;
@@ -239,15 +226,15 @@ function renderCountyDetails(county: CountyDatum | null) {
   };
 
   detailsBody.innerHTML = `
-    <div class="rounded-2xl border border-white/10 bg-white/60 p-4 text-slate-700 shadow-inner dark:border-white/10 dark:bg-slate-900/40 dark:text-slate-100">
+    <div class="rounded-2xl border border-white/10 bg-black/40 p-4 text-white/80 shadow-inner backdrop-blur">
       <div class="flex flex-wrap items-baseline justify-between gap-2">
-        <h3 class="text-xl font-semibold text-slate-900 dark:text-white">${county.county}, ${county.state}</h3>
-        <span class="text-xs font-mono text-slate-500 dark:text-slate-300">${county.fips}</span>
+        <h3 class="text-xl font-semibold text-white">${county.county}, ${county.state}</h3>
+        <span class="text-xs font-mono text-white/60">${county.fips}</span>
       </div>
-      <p class="text-xs text-slate-500 dark:text-slate-300">PM₂.₅ averaging window: ${state.pmYearLabel}</p>
+      <p class="text-xs text-white/60">PM₂.₅ averaging window: ${state.pmYearLabel}</p>
       ${county.hasDataGap ? '<p class="mt-1 text-xs text-amber-500">One or more health measures are missing for this county.</p>' : ''}
     </div>
-    <div class="overflow-hidden rounded-2xl border border-white/10 bg-white/70 shadow-inner dark:border-white/10 dark:bg-slate-900/50">
+    <div class="overflow-hidden rounded-2xl border border-white/10 bg-black/40 shadow-inner backdrop-blur">
       <table class="county-table">
         <thead>
           <tr>
@@ -278,11 +265,11 @@ function renderCountyDetails(county: CountyDatum | null) {
       </table>
     </div>
     <div class="panel-surface flex flex-col gap-2">
-      <p class="text-sm font-semibold text-slate-900 dark:text-white">Chronic disease inputs</p>
+      <p class="text-sm font-semibold text-white">Chronic disease inputs</p>
       <ul class="grid grid-cols-1 gap-2 sm:grid-cols-2">
         ${PLACE_KEYS.map((key) => `
-          <li class="flex flex-col gap-0.5 text-sm text-slate-600 dark:text-slate-200">
-            <span class="font-semibold text-slate-900 dark:text-white">${placeLabels[key]}</span>
+          <li class="flex flex-col gap-0.5 text-sm text-white/70">
+            <span class="font-semibold text-white">${placeLabels[key]}</span>
             <span>${withPercent((county[key] as number | null) ?? null)}</span>
           </li>
         `).join('')}
@@ -440,7 +427,7 @@ Promise.all([loadPlaces(), loadPm(), loadGeography()])
     mapPanel.appendChild(mapContainer);
 
     regressionBadge = document.createElement('div');
-    regressionBadge.className = 'pointer-events-none absolute bottom-4 left-4 z-10 flex items-center gap-2 rounded-lg bg-slate-900/80 px-3 py-2 text-xs font-medium text-slate-100 shadow-lg';
+    regressionBadge.className = 'pointer-events-none absolute bottom-4 left-4 z-10 flex items-center gap-2 rounded-lg bg-black/70 px-3 py-2 text-xs font-medium text-white/80 shadow-lg';
     mapPanel.appendChild(regressionBadge);
 
     mapInstance = new CountyMap(mapContainer, geography, undefined, {

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,7 +5,19 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: light dark;
+  color-scheme: dark;
+  --bg-base: #020403;
+  --bg-card: rgba(9, 16, 12, 0.92);
+  --bg-panel: rgba(7, 13, 10, 0.88);
+  --bg-panel-hover: rgba(18, 33, 25, 0.96);
+  --border-soft: rgba(53, 94, 59, 0.4);
+  --accent: #355e3b;
+  --accent-soft: #4c8f60;
+  --accent-glow: rgba(76, 143, 96, 0.35);
+  --accent-bright: rgba(103, 169, 123, 0.85);
+  --text-primary: #f6f7f4;
+  --text-muted: #9fb4a2;
+  --text-subtle: rgba(168, 190, 174, 0.75);
 }
 
 @layer base {
@@ -15,11 +27,13 @@
 
   body {
     font-family: 'Plus Jakarta Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    @apply bg-slate-950 text-slate-100 antialiased;
-    background-image: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.12), transparent 45%),
-      radial-gradient(circle at 80% 10%, rgba(129, 140, 248, 0.18), transparent 50%),
-      radial-gradient(circle at 50% 80%, rgba(45, 212, 191, 0.12), transparent 40%);
+    color: var(--text-primary);
+    background-color: var(--bg-base);
+    background-image: radial-gradient(circle at 20% 10%, rgba(76, 143, 96, 0.18), transparent 55%),
+      radial-gradient(circle at 80% -10%, rgba(34, 61, 44, 0.35), transparent 60%),
+      radial-gradient(circle at 50% 80%, rgba(25, 54, 34, 0.25), transparent 45%);
     background-attachment: fixed;
+    -webkit-font-smoothing: antialiased;
   }
 
   h1,
@@ -27,144 +41,302 @@
   h3,
   h4,
   h5 {
-    @apply font-semibold text-slate-900 dark:text-slate-100;
+    color: var(--text-primary);
+    font-weight: 600;
   }
 
   a {
-    @apply font-semibold text-primary transition hover:text-primary/80;
+    font-weight: 600;
+    color: var(--accent-soft);
+    transition: color 150ms ease, text-shadow 150ms ease;
+  }
+
+  a:hover {
+    color: var(--accent);
+    text-shadow: 0 0 8px rgba(76, 143, 96, 0.35);
   }
 }
 
 .card {
-  @apply relative overflow-hidden rounded-3xl border border-white/15 bg-white/70 p-6 shadow-[0_30px_90px_-45px_rgba(15,23,42,0.9)] backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/70;
+  position: relative;
+  overflow: hidden;
+  border-radius: 1.5rem;
+  border: 1px solid var(--border-soft);
+  background: var(--bg-card);
+  padding: 1.5rem;
+  box-shadow: 0 32px 90px -45px rgba(5, 10, 8, 0.9);
+  backdrop-filter: blur(18px);
 }
 
 .card::before {
   content: '';
-  @apply pointer-events-none absolute -right-20 top-10 h-56 w-56 rounded-full bg-primary/20 blur-3xl;
+  position: absolute;
+  pointer-events: none;
+  top: 2.5rem;
+  right: -4.5rem;
+  width: 14rem;
+  height: 14rem;
+  border-radius: 9999px;
+  background: var(--accent-glow);
+  filter: blur(60px);
 }
 
 .card::after {
   content: '';
-  @apply pointer-events-none absolute -bottom-16 left-12 h-44 w-44 rounded-full bg-emerald-400/10 blur-3xl;
+  position: absolute;
+  pointer-events: none;
+  left: 3rem;
+  bottom: -4rem;
+  width: 11rem;
+  height: 11rem;
+  border-radius: 9999px;
+  background: rgba(33, 78, 49, 0.45);
+  filter: blur(60px);
 }
 
 .control-label {
-  @apply text-[13px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-300;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--text-muted);
 }
 
 .form-control {
-  @apply w-full rounded-2xl border border-white/30 bg-white/80 px-4 py-2.5 text-sm font-medium text-slate-800 shadow-inner transition focus:border-primary/40 focus:outline-none focus:ring-2 focus:ring-primary/30 dark:border-white/10 dark:bg-slate-900/70 dark:text-slate-100 dark:shadow-[inset_0_1px_0_0_rgba(148,163,184,0.12)];
+  width: 100%;
+  border-radius: 1.25rem;
+  border: 1px solid var(--border-soft);
+  background: rgba(8, 14, 11, 0.9);
+  padding: 0.625rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  box-shadow: inset 0 1px 0 rgba(159, 180, 162, 0.12);
+  transition: border-color 150ms ease, box-shadow 150ms ease, background-color 150ms ease;
+}
+
+.form-control::placeholder {
+  color: var(--text-subtle);
+}
+
+.form-control:focus {
+  outline: none;
+  border-color: var(--accent-soft);
+  background: rgba(13, 24, 18, 0.95);
+  box-shadow: 0 0 0 3px rgba(76, 143, 96, 0.2);
 }
 
 .input-description {
-  @apply text-xs leading-relaxed text-slate-500 dark:text-slate-300;
+  font-size: 0.75rem;
+  line-height: 1.6;
+  color: var(--text-muted);
 }
 
 .section-heading {
-  @apply text-xs font-semibold uppercase tracking-[0.32em] text-primary/80;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--accent-soft);
 }
 
 .panel-surface {
-  @apply rounded-2xl border border-white/10 bg-white/60 p-4 shadow-inner transition dark:border-white/10 dark:bg-slate-900/40;
+  border-radius: 1.25rem;
+  border: 1px solid var(--border-soft);
+  background: var(--bg-panel);
+  padding: 1rem;
+  box-shadow: inset 0 1px 0 rgba(15, 25, 19, 0.4);
+  transition: border-color 150ms ease, background-color 150ms ease, box-shadow 150ms ease;
 }
 
 .panel-surface:hover {
-  @apply border-primary/40 shadow-[0_18px_48px_-30px_rgba(30,64,175,0.6)];
+  border-color: var(--accent);
+  background: var(--bg-panel-hover);
+  box-shadow: 0 22px 48px -30px rgba(18, 38, 27, 0.8);
 }
 
 .metric-tabs {
-  @apply grid gap-3 sm:grid-cols-3;
+  display: grid;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .metric-tabs {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 .metric-tab {
-  @apply flex flex-col gap-1 rounded-3xl border border-white/15 bg-white/70 p-4 text-left text-slate-600 shadow-[0_30px_90px_-60px_rgba(15,23,42,0.7)] transition hover:border-primary/40 hover:bg-primary/10 hover:text-primary dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  border-radius: 1.5rem;
+  border: 1px solid var(--border-soft);
+  background: rgba(10, 17, 13, 0.85);
+  padding: 1rem;
+  text-align: left;
+  color: var(--text-muted);
+  box-shadow: 0 30px 90px -60px rgba(5, 12, 9, 0.7);
+  transition: border-color 150ms ease, background-color 150ms ease, color 150ms ease, transform 150ms ease;
+}
+
+.metric-tab:hover {
+  border-color: var(--accent);
+  background: rgba(16, 30, 23, 0.95);
+  color: var(--text-primary);
+  transform: translateY(-2px);
 }
 
 .metric-tab-active {
-  @apply border-primary/60 bg-primary/15 text-primary dark:border-primary/60 dark:bg-primary/25 dark:text-primary/80;
+  border-color: var(--accent);
+  background: rgba(27, 47, 35, 0.9);
+  color: var(--text-primary);
+  box-shadow: 0 22px 54px -30px rgba(27, 62, 39, 0.55);
 }
 
 .metric-tab-label {
-  @apply text-lg font-semibold text-slate-900 transition dark:text-white;
-}
-
-.metric-tab-active .metric-tab-label {
-  @apply text-primary dark:text-white;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  transition: color 150ms ease;
 }
 
 .metric-tab-helper {
-  @apply text-xs text-slate-500 transition dark:text-slate-300;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  transition: color 150ms ease;
 }
 
 .metric-tab-active .metric-tab-helper {
-  @apply text-primary/80 dark:text-primary/70;
+  color: rgba(172, 206, 182, 0.92);
 }
 
 .segmented {
-  @apply flex flex-wrap gap-2;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
 .segmented-button {
-  @apply rounded-full border border-white/20 bg-white/70 px-4 py-1.5 text-xs font-semibold text-slate-600 transition hover:border-primary/50 hover:bg-primary/10 hover:text-primary dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200;
+  border-radius: 9999px;
+  border: 1px solid var(--border-soft);
+  background: rgba(9, 16, 12, 0.9);
+  padding: 0.375rem 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  transition: border-color 150ms ease, background-color 150ms ease, color 150ms ease;
+}
+
+.segmented-button:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
 }
 
 .segmented-button-active {
-  @apply border-primary/60 bg-primary/20 text-primary dark:border-primary/60 dark:bg-primary/30 dark:text-primary/80;
+  border-color: var(--accent);
+  background: rgba(27, 47, 35, 0.9);
+  color: var(--text-primary);
 }
 
 .county-table {
-  @apply min-w-full divide-y divide-white/10 text-sm dark:divide-white/10;
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+  color: var(--text-muted);
 }
 
 .county-table thead {
-  @apply bg-white/70 text-left text-[11px] font-semibold uppercase tracking-[0.2em] text-slate-500 dark:bg-slate-900/50 dark:text-slate-300;
+  background: rgba(12, 21, 16, 0.9);
+  text-align: left;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
 
 .county-table th,
 .county-table td {
-  @apply px-4 py-3 align-top;
+  padding: 0.75rem 1rem;
+  vertical-align: top;
 }
 
 .county-table tbody tr {
-  @apply border-t border-white/10 dark:border-white/10;
+  border-top: 1px solid rgba(33, 55, 40, 0.4);
 }
 
 .metric-row-active {
-  @apply bg-primary/10 text-primary dark:bg-primary/25 dark:text-primary/80;
+  background: rgba(53, 94, 59, 0.18);
+  color: rgba(194, 220, 201, 0.95);
 }
 
 .metric-row-active th,
 .metric-row-active td {
-  @apply text-primary dark:text-primary/80;
+  color: rgba(194, 220, 201, 0.95);
 }
 
 .metric-row-helper {
-  @apply text-xs text-slate-500 dark:text-slate-300;
+  font-size: 0.75rem;
+  color: var(--text-muted);
 }
 
 .btn-link {
-  @apply text-xs font-semibold text-primary transition hover:text-primary/80;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--accent-soft);
+  transition: color 150ms ease;
+}
+
+.btn-link:hover {
+  color: var(--accent);
 }
 
 .btn-primary {
-  @apply inline-flex items-center justify-center rounded-full bg-gradient-to-r from-primary to-indigo-500 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-white shadow-lg shadow-primary/25 transition hover:from-primary/90 hover:to-indigo-500/90;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  background-image: linear-gradient(135deg, var(--accent) 0%, rgba(53, 94, 59, 0.9) 40%, rgba(103, 169, 123, 0.95) 100%);
+  padding: 0.5rem 1rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #ffffff;
+  box-shadow: 0 18px 44px -24px rgba(76, 143, 96, 0.65);
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 24px 60px -24px rgba(103, 169, 123, 0.75);
 }
 
 .btn-pill {
-  @apply rounded-full border border-transparent bg-white/70 px-3 py-1 text-xs font-medium text-slate-700 shadow-sm transition hover:border-primary/40 hover:bg-primary/10 dark:bg-slate-900/60 dark:text-slate-100;
+  border-radius: 9999px;
+  border: 1px solid transparent;
+  background: rgba(11, 18, 14, 0.85);
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  transition: border-color 150ms ease, background-color 150ms ease;
 }
 
-.search-result {
-  @apply flex flex-col gap-0.5 rounded-2xl border border-transparent bg-white/70 px-3 py-2 text-left text-sm text-slate-700 transition hover:border-primary/40 hover:bg-primary/10 dark:bg-slate-900/60 dark:text-slate-100;
-}
-
-.search-result span {
-  @apply font-mono text-[11px] text-slate-400;
+.btn-pill:hover {
+  border-color: var(--accent);
+  background: rgba(24, 41, 31, 0.95);
 }
 
 .weight-percent {
-  @apply w-12 text-right text-xs font-semibold tabular-nums text-slate-500 transition group-hover:text-primary/80;
+  width: 3rem;
+  text-align: right;
+  font-size: 0.75rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+  transition: color 150ms ease;
 }
 
 input[type='range'] {
@@ -174,7 +346,7 @@ input[type='range'] {
 input[type='range']::-webkit-slider-runnable-track {
   height: 0.35rem;
   border-radius: 9999px;
-  background: linear-gradient(90deg, rgba(29, 78, 216, 0.65), rgba(129, 140, 248, 0.6));
+  background: linear-gradient(90deg, rgba(53, 94, 59, 0.85), rgba(103, 169, 123, 0.75));
 }
 
 input[type='range']::-webkit-slider-thumb {
@@ -182,50 +354,81 @@ input[type='range']::-webkit-slider-thumb {
   width: 18px;
   height: 18px;
   border-radius: 9999px;
-  background: white;
-  border: 2px solid rgba(29, 78, 216, 0.7);
-  box-shadow: 0 10px 30px -12px rgba(30, 64, 175, 0.7);
+  background: #0e1812;
+  border: 2px solid var(--accent-bright);
+  box-shadow: 0 10px 30px -12px rgba(76, 143, 96, 0.7);
 }
 
 input[type='range']::-moz-range-track {
   height: 0.35rem;
   border-radius: 9999px;
-  background: linear-gradient(90deg, rgba(29, 78, 216, 0.65), rgba(129, 140, 248, 0.6));
+  background: linear-gradient(90deg, rgba(53, 94, 59, 0.85), rgba(103, 169, 123, 0.75));
 }
 
 input[type='range']::-moz-range-thumb {
   width: 18px;
   height: 18px;
   border-radius: 9999px;
-  background: white;
-  border: 2px solid rgba(29, 78, 216, 0.7);
-  box-shadow: 0 10px 30px -12px rgba(30, 64, 175, 0.7);
+  background: #0e1812;
+  border: 2px solid var(--accent-bright);
+  box-shadow: 0 10px 30px -12px rgba(76, 143, 96, 0.7);
 }
 
 .map-panel-overlay {
-  @apply pointer-events-none absolute inset-0 rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-transparent to-primary/15;
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(53, 94, 59, 0.15);
+  background: linear-gradient(135deg, rgba(53, 94, 59, 0.15), transparent 45%, rgba(28, 51, 35, 0.2));
 }
 
 .map-legend {
-  @apply absolute right-4 top-4 z-10 flex w-60 flex-col gap-2 rounded-2xl border border-white/20 bg-white/80 p-4 text-xs text-slate-700 shadow-xl backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/80 dark:text-slate-200;
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+  z-index: 10;
+  display: flex;
+  width: 15rem;
+  flex-direction: column;
+  gap: 0.5rem;
+  border-radius: 1.25rem;
+  border: 1px solid var(--border-soft);
+  background: rgba(10, 16, 12, 0.92);
+  padding: 1rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  box-shadow: 0 24px 60px -30px rgba(10, 20, 14, 0.8);
+  backdrop-filter: blur(16px);
 }
 
 .map-tooltip {
-  @apply pointer-events-none absolute hidden max-w-xs rounded-2xl border border-primary/30 bg-slate-950/90 px-5 py-4 text-sm text-slate-100 shadow-2xl backdrop-blur;
+  pointer-events: none;
+  position: absolute;
+  display: none;
+  max-width: 18rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(76, 143, 96, 0.35);
+  background: rgba(4, 8, 6, 0.92);
+  padding: 1rem 1.25rem;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+  box-shadow: 0 30px 60px -25px rgba(15, 30, 22, 0.85);
+  backdrop-filter: blur(12px);
 }
 
 [data-hatched='true'] {
   background-image: repeating-linear-gradient(
     45deg,
-    rgba(15, 23, 42, 0.2) 0,
-    rgba(15, 23, 42, 0.2) 2px,
+    rgba(36, 55, 41, 0.25) 0,
+    rgba(36, 55, 41, 0.25) 2px,
     transparent 2px,
     transparent 6px
   );
 }
 
 .county-selected {
-  stroke: #1d4ed8 !important;
+  stroke: var(--accent-soft) !important;
   stroke-width: 1.2 !important;
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,7 @@ export default {
   theme: {
     extend: {
       colors: {
-        primary: '#1d4ed8'
+        primary: '#355E3B'
       },
       fontFamily: {
         sans: ['"Plus Jakarta Sans"', 'system-ui', 'sans-serif']


### PR DESCRIPTION
## Summary
- restyle the application with a blackout-inspired dark theme and hunter green accent palette
- refresh UI components, typography, and map chrome to ensure legible white text throughout
- remove the counties search panel and polish helper copy to match the streamlined controls

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d58d46eec48327b93aa8ce29649e66