### PR TITLE
Add combined about panel

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -117,18 +117,6 @@ mapColumn.appendChild(controlPanel);
 
 const detailsBody = detailsCard.querySelector('[data-role="county-details"]') as HTMLDivElement;
 
-const helperNote = document.createElement('div');
-helperNote.className = 'panel-surface text-sm leading-relaxed text-white/80';
-helperNote.innerHTML = `
-  <p class="text-sm font-semibold text-white">How to read this view</p>
-  <ul class="mt-2 list-disc space-y-1 pl-5">
-    <li>Tabs above the map switch between Health, air pollution, and the gap between them.</li>
-    <li>Click any county to update the table and keep the numbers visible while you explore.</li>
-    <li>Use the controls on the right to change the color groupings or tweak the blended index weights.</li>
-  </ul>
-`;
-mapColumn.appendChild(helperNote);
-
 const { weights: initialWeights, active: initialActive } = UIController.initialWeights();
 
 const state: AppState = {
@@ -169,6 +157,35 @@ const ui = new UIController(controlPanel, { ...initialWeights }, { ...initialAct
     renderCountyDetails(state.selectedCounty);
   }
 });
+
+const aboutPanel = document.createElement('section');
+aboutPanel.className = 'panel-surface flex flex-col gap-6 text-sm leading-relaxed text-white/80';
+aboutPanel.innerHTML = `
+  <div class="flex flex-col gap-2">
+    <span class="section-heading">About this explorer</span>
+    <h2 class="text-lg font-semibold text-white">How to read &amp; data notes</h2>
+  </div>
+  <div class="grid gap-6 md:grid-cols-2">
+    <div>
+      <p class="text-sm font-semibold text-white">How to read this view</p>
+      <ul class="mt-2 list-disc space-y-1 pl-5">
+        <li>Tabs above the map switch between Health, air pollution, and the gap between them.</li>
+        <li>Click any county to update the table and keep the numbers visible while you explore.</li>
+        <li>Use the controls on the right to change the color groupings or tweak the blended index weights.</li>
+      </ul>
+    </div>
+    <div>
+      <p class="text-sm font-semibold text-white">Data notes</p>
+      <ul class="mt-2 list-disc space-y-1 pl-5">
+        <li>CDC PLACES 2024 release (crude prevalence) for chronic conditions.</li>
+        <li>EPA Air Quality System PM₂.₅ monitor annual means averaged across available monitors.</li>
+        <li>Residuals derive from an ordinary least squares fit of HBI on pollution.</li>
+        <li>Methodology and limitations described in the README.</li>
+      </ul>
+    </div>
+  </div>
+`;
+layout.appendChild(aboutPanel);
 let derived: DerivedData | null = null;
 let baseCounties: CountyDatum[] = [];
 let mapInstance: CountyMap | null = null;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -247,19 +247,6 @@ export class UIController {
     contentGrid.appendChild(this.outlierSection);
     this.setOutlierVisibility(false);
 
-    const notes = document.createElement('div');
-    notes.className =
-      'rounded-2xl border border-white/10 bg-white/5 p-4 text-xs leading-relaxed text-white/80 shadow-inner backdrop-blur xl:col-span-4';
-    notes.innerHTML = `
-      <p class="text-sm font-semibold text-white">Data notes</p>
-      <ul class="mt-2 list-disc space-y-1 pl-4">
-        <li>CDC PLACES 2024 release (crude prevalence) for chronic conditions.</li>
-        <li>EPA Air Quality System PM₂.₅ monitor annual means averaged across available monitors.</li>
-        <li>Residuals derive from an ordinary least squares fit of HBI on pollution.</li>
-        <li>Methodology and limitations described in the README.</li>
-      </ul>
-    `;
-    contentGrid.appendChild(notes);
     updateHash(this.weights, this.active);
   }
 


### PR DESCRIPTION
## Summary
- replace the separate “How to read this view” note and sidebar data notes with a single About panel
- add the combined panel to the bottom of the layout so guidance and data notes stay together

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d58f5495a083278365fba4bddb6cd4