### PR TITLE
Add pollution minus health view

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -71,10 +71,11 @@ export function combineData(places: PlacesRecord[], pm: PmRecord[]): CountyDatum
         hbi: null,
         exposure: null,
         residual: null,
+        pollutionMinusHealth: null,
         expectedHbi: null,
         hbiZ: null,
         exposureZ: null,
-        percentile: { hbi: null, exposure: null, residual: null },
+        percentile: { hbi: null, exposure: null, residual: null, pollutionMinusHealth: null },
         hasDataGap: false
       } satisfies CountyDatum;
     })

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -299,5 +299,6 @@ export function formatNumber(value: number | null): string {
 export function metricLabel(metric: MetricKey): string {
   if (metric === 'hbi') return 'Health Burden Index';
   if (metric === 'exposure') return 'Exposure Index';
-  return 'Residual (HBI – Expected)';
+  if (metric === 'residual') return 'Residual (HBI – Expected)';
+  return 'Residual (Expected – HBI)';
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type MetricKey = 'hbi' | 'exposure' | 'residual';
+export type MetricKey = 'hbi' | 'exposure' | 'residual' | 'pollutionMinusHealth';
 
 export type BreakMode = 'quantile' | 'equal' | 'jenks';
 
@@ -33,6 +33,7 @@ export interface CountyDatum {
   hbi: number | null;
   exposure: number | null;
   residual: number | null;
+  pollutionMinusHealth: number | null;
   expectedHbi: number | null;
   hbiZ: number | null;
   exposureZ: number | null;


### PR DESCRIPTION
## Summary
- add a fourth "Pollution minus health" tab and detail row to flip the residual visualization
- compute and persist the reverse residual metric with appropriate percentiles and legend logic
- update the choropleth color scaling and copy to support the new gap view

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d5904bb3488327a2f9a050cedb7316