### PR TITLE
Adjust inset layout for Alaska and Hawaii

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -48,7 +48,16 @@ export async function loadGeography(): Promise<GeographyData> {
     throw new Error('Failed to load topology');
   }
   const counties = feature(topology as any, (topology as any).objects.counties) as GeoJSON.FeatureCollection;
-  const statesMesh = mesh(topology as any, (topology as any).objects.states);
+  const insetStateCodes = new Set(['02', '15']);
+  const statesObject = (topology as any).objects.states;
+  const contiguousStates = {
+    type: 'GeometryCollection',
+    geometries: statesObject.geometries.filter((geom: { id?: string | number }) => {
+      const id = geom.id != null ? geom.id.toString().padStart(2, '0') : '';
+      return !insetStateCodes.has(id);
+    })
+  };
+  const statesMesh = mesh(topology as any, contiguousStates as any, (a, b) => a !== b);
   return { counties, statesMesh };
 }
 


### PR DESCRIPTION
## Summary
- resize the Alaska inset with a dedicated projection and custom dimensions
- keep Alaska and Hawaii only in inset side panels and drop the unused Puerto Rico panel
- limit the states mesh to contiguous states so Alaska and Hawaii no longer appear on the main map

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d595d1e998832795efef19aaf83dc0