### PR TITLE
Limit residual map to positive values with new color scales

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,8 +9,7 @@ import {
   formatBreaks,
   formatNumber,
   normalizeSeries,
-  percentileRanks,
-  symmetricBreaks
+  percentileRanks
 } from './stats';
 import { CountyMap } from './map';
 import { UIController } from './ui';
@@ -394,8 +393,16 @@ function computeLegend(metric: MetricKey, data: CountyDatum[], mode: BreakMode) 
     return { bins: [], labels: [] };
   }
   if (metric === 'residual' || metric === 'pollutionMinusHealth') {
-    const breaks = symmetricBreaks(values, 5);
-    return formatBreaks(breaks);
+    const positives = values.filter((v) => v > 0);
+    if (positives.length === 0) {
+      return { bins: [], labels: [] };
+    }
+    const sequential = computeBreaks(positives, mode);
+    if (sequential.bins.length < 2) {
+      return sequential;
+    }
+    const bins = [0, ...sequential.bins.slice(1)];
+    return formatBreaks(bins);
   }
   return computeBreaks(values, mode);
 }

--- a/src/map.ts
+++ b/src/map.ts
@@ -295,13 +295,14 @@ export class CountyMap {
       return d3.scaleThreshold().domain([0]).range([DEFAULT_COLORS.noData]);
     }
     const classes = Math.max(1, bins.length - 1);
-    const usesDiverging = this.currentMetric === 'residual' || this.currentMetric === 'pollutionMinusHealth';
-    const colors = usesDiverging
-      ? d3.quantize(
-          (t) => d3.interpolateRdBu(this.currentMetric === 'residual' ? 1 - t : t),
-          classes
-        )
-      : d3.quantize((t) => d3.interpolateYlOrRd(t * 0.85 + 0.15), classes);
+    let colors: string[];
+    if (this.currentMetric === 'residual') {
+      colors = d3.quantize((t) => d3.interpolateYlOrRd(t), classes);
+    } else if (this.currentMetric === 'pollutionMinusHealth') {
+      colors = d3.quantize((t) => d3.interpolateYlGn(t), classes);
+    } else {
+      colors = d3.quantize((t) => d3.interpolateYlOrRd(t * 0.85 + 0.15), classes);
+    }
     return d3.scaleThreshold<number, string>().domain(bins.slice(1, -1)).range(colors);
   }
 
@@ -414,8 +415,15 @@ export class CountyMap {
   private getMetricValue(datum: CountyDatum): number | null {
     if (this.currentMetric === 'hbi') return datum.hbi;
     if (this.currentMetric === 'exposure') return datum.exposure;
-    if (this.currentMetric === 'residual') return datum.residual;
-    return datum.pollutionMinusHealth;
+    if (this.currentMetric === 'residual') {
+      return datum.residual != null && datum.residual > 0 ? datum.residual : null;
+    }
+    if (this.currentMetric === 'pollutionMinusHealth') {
+      return datum.pollutionMinusHealth != null && datum.pollutionMinusHealth > 0
+        ? datum.pollutionMinusHealth
+        : null;
+    }
+    return null;
   }
 
   private applySelection() {


### PR DESCRIPTION
## Summary
- filter health-minus-pollution and pollution-minus-health metrics to only map positive residuals
- rebuild their legends from zero using sequential breaks for better range coverage
- recolor the residual tabs with yellow→red and yellow→green ramps where the warmest color highlights the largest values

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d59769191483279a30786509be2a2c