### PR TITLE
Add low-burden outliers panel for pollution minus health view

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -82,11 +82,14 @@ export interface AppState {
   selectedCounty: CountyDatum | null;
 }
 
+export type OutlierMetric = 'residual' | 'pollutionMinusHealth';
+
 export interface Outlier {
   fips: string;
   county: string;
   state: string;
-  residual: number;
+  metric: OutlierMetric;
+  value: number;
   exposure: number | null;
   hbi: number | null;
 }


### PR DESCRIPTION
## Summary
- surface the top pollution-minus-health gaps alongside the existing high-burden residual outliers
- update the sidebar panel copy, value labels, and CSV export naming to reflect the active outlier mode
- generalize the Outlier shape so both residual and pollution-minus-health panels share the same rendering logic

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d68c5a1de48327b3378339ef53f3ce